### PR TITLE
[RFC]: vcproj/filters: initial filters implementation using bigtree

### DIFF
--- a/examples/list_filters.py
+++ b/examples/list_filters.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+# List filter structure project in a solution.
+
+import vcproj.solution
+import vcproj.project
+import vcproj.filters
+
+import os
+
+solution_file = '../vcproj/tests/test_solution/test.sln'
+solution = vcproj.solution.parse(solution_file)
+
+# FIXME: add a helpers file
+def convert_seperator(token):
+    return token.replace("\\", str(os.sep))
+
+# FIXME: add solution.project_filters()
+for project_file in solution.project_files():
+    filter_file = os.path.join(os.path.dirname(solution_file), convert_seperator(project_file) + ".filters")
+    filters = vcproj.filters.parse(filter_file)
+    filters.list_tree()
+
+for project_file in solution.project_files():
+    filter_file = os.path.join(os.path.dirname(solution_file), convert_seperator(project_file) + ".filters")
+    filters = vcproj.filters.parse(filter_file)
+    filters.list_tree(attr_list=["realpath", "UniqueIdentifier", "Type"])

--- a/vcproj/filters.py
+++ b/vcproj/filters.py
@@ -1,0 +1,70 @@
+"""Visual C++ project filters file."""
+
+import xml.etree.ElementTree as ET
+import re, string
+import os
+from bigtree import list_to_tree, print_tree, dict_to_tree
+
+__all__ = ['Project', 'parse']
+
+_MS_BUILD_NAMESPACE = "http://schemas.microsoft.com/developer/msbuild/2003"
+
+try:
+    _register_namespace = ET.register_namespace
+except AttributeError:
+    def _register_namespace(prefix, uri):
+        ET._namespace_map[uri] = prefix
+
+class Project(object):
+    """Visual C++ project file (.vcxproj)."""
+
+    def __init__(self, filename):
+        """Create a Project instance for project file *filename*."""
+        _register_namespace('', _MS_BUILD_NAMESPACE)
+        self.filename = filename
+        self.xml = ET.parse(filename)
+        # FIXME: consider using the project file and get RootNamespace instead
+        self.root_namespace = os.path.basename(self.filename).split(".")[0]
+
+    def convert_seperator(self, token):
+        """Convert seperator from Windows to OS"""
+        return token.replace("\\", str(os.sep))
+
+    def get_type(self, tag):
+        """Get Type, basically remove the _MS_BUILD_NAMESPACE."""
+        return str(tag).replace("{" + _MS_BUILD_NAMESPACE + "}", "")
+
+    def get_tree(self):
+        """Get project filter tree."""
+        path_dict = {}
+        myroot = self.xml.getroot()
+        for y in myroot[0:]:
+            for x in y:
+                    type = self.get_type(x.tag)
+                    if not "Filter" == type:
+                        folder=""
+                        filename=""
+                        realpath=""
+                        if len(x) == 1:
+                            folder = self.convert_seperator(x[0].text)
+                            if folder:
+                                realpath = self.convert_seperator(x.attrib['Include'])
+                                filename = "/" + os.path.basename(realpath)
+                        else:
+                            realpath = self.convert_seperator(x.attrib['Include'])
+                            filename = x.attrib['Include']
+                        filter_path = self.root_namespace + "/" + str(folder) + str(filename)
+                        path_dict[filter_path] = {"realpath": realpath, "Type": type}
+                    else:
+                        filter_path = self.root_namespace + "/" + self.convert_seperator(x.attrib['Include'])
+                        path_dict[filter_path] = {"realpath": "", "UniqueIdentifier": x[0].text, "Type": type}
+
+        return dict_to_tree(path_dict)
+
+    def list_tree(self, attr_list=[]):
+        """List project filter tree."""
+        print_tree(self.get_tree(), attr_list=attr_list)
+
+def parse(filename):
+    """Parse project file filename and return Project instance."""
+    return Project(filename)


### PR DESCRIPTION
Hi all,
I am currently working to add vcxproj.filters files support. As I'm coming from a Linux workflow and find it very hard to feel at home with Visual Studio on Windows.

This is a very basic initial implementation. Just POC and just for RFC.

The current goal is to list a solution as it is shown in Visual Studio. It uses bigtree as the backing data structure. For writing the vcxproj.filters file I plan to make it as least destructive as possible.

My long term goal is to manipulate vcxproj and vcxproj.filters to add, remove and move files between projects of a solution.

Another goal is to create a merge tool for git. As merging vcxproj and vcxproj.filters is currently a pain if multiple people add and remove files form the filters and project.  

It also changes the separator to a os specific one. Later i will try to change the file to match the case on a case sensitive file system. This will also be non destructive to the original file.

Therefore my first question is if you want to add such a thing to your implementation as the goal of this library might differ. Otherwise I might create a fork of it.

Here is the output of my list_filter.py example:

First the basic listing without any further information:

test
├── Source Files
│   ├── stdafx.cpp
│   └── test.cpp
├── Header Files
│   ├── stdafx.h
│   ├── targetver.h
│   ├── Resource.h
│   └── test.h
├── Resource Files
│   ├── small.ico
│   ├── test.ico
│   └── test.rc
└── ReadMe.txt
lib1
├── Source Files
│   ├── stdafx.cpp
│   ├── lib1.cpp
│   └── dllmain.cpp
├── Header Files
│   ├── stdafx.h
│   └── targetver.h
├── Resource Files
└── ReadMe.txt
lib2
├── Source Files
│   └── stdafx.cpp
├── Header Files
│   ├── stdafx.h
│   └── targetver.h
├── Resource Files
└── ReadMe.txt

The second part uses the attr_list argument of bigtree to gain more information about the files. So in theory you are able to just show or search ClCompile files to use them as msbuild targets for compiling. Think of it as compile file feature from Visual Stuidio. I use the project to create xonsh functions for compilation.

test
├── Source Files [realpath=, UniqueIdentifier={4FC737F1-C7A5-4376-A066-2A32D752A2FF}, Type=Filter]
│   ├── stdafx.cpp [realpath=stdafx.cpp, UniqueIdentifier=nan, Type=ClCompile]
│   └── test.cpp [realpath=test.cpp, UniqueIdentifier=nan, Type=ClCompile]
├── Header Files [realpath=, UniqueIdentifier={93995380-89BD-4b04-88EB-625FBE52EBFB}, Type=Filter]
│   ├── stdafx.h [realpath=stdafx.h, UniqueIdentifier=nan, Type=ClInclude]
│   ├── targetver.h [realpath=targetver.h, UniqueIdentifier=nan, Type=ClInclude]
│   ├── Resource.h [realpath=Resource.h, UniqueIdentifier=nan, Type=ClInclude]
│   └── test.h [realpath=test.h, UniqueIdentifier=nan, Type=ClInclude]
├── Resource Files [realpath=, UniqueIdentifier={67DA6AB6-F800-4c08-8B7A-83BB121AAD01}, Type=Filter]
│   ├── small.ico [realpath=small.ico, UniqueIdentifier=nan, Type=None]
│   ├── test.ico [realpath=test.ico, UniqueIdentifier=nan, Type=None]
│   └── test.rc [realpath=test.rc, UniqueIdentifier=nan, Type=ResourceCompile]
└── ReadMe.txt [realpath=ReadMe.txt, UniqueIdentifier=nan, Type=None]
lib1
├── Source Files [realpath=, UniqueIdentifier={4FC737F1-C7A5-4376-A066-2A32D752A2FF}, Type=Filter]
│   ├── stdafx.cpp [realpath=stdafx.cpp, UniqueIdentifier=nan, Type=ClCompile]
│   ├── lib1.cpp [realpath=lib1.cpp, UniqueIdentifier=nan, Type=ClCompile]
│   └── dllmain.cpp [realpath=dllmain.cpp, UniqueIdentifier=nan, Type=ClCompile]
├── Header Files [realpath=, UniqueIdentifier={93995380-89BD-4b04-88EB-625FBE52EBFB}, Type=Filter]
│   ├── stdafx.h [realpath=stdafx.h, UniqueIdentifier=nan, Type=ClInclude]
│   └── targetver.h [realpath=targetver.h, UniqueIdentifier=nan, Type=ClInclude]
├── Resource Files [realpath=, UniqueIdentifier={67DA6AB6-F800-4c08-8B7A-83BB121AAD01}, Type=Filter]
└── ReadMe.txt [realpath=ReadMe.txt, UniqueIdentifier=nan, Type=None]
lib2
├── Source Files [realpath=, UniqueIdentifier={4FC737F1-C7A5-4376-A066-2A32D752A2FF}, Type=Filter]
│   └── stdafx.cpp [realpath=stdafx.cpp, UniqueIdentifier=nan, Type=ClCompile]
├── Header Files [realpath=, UniqueIdentifier={93995380-89BD-4b04-88EB-625FBE52EBFB}, Type=Filter]
│   ├── stdafx.h [realpath=stdafx.h, UniqueIdentifier=nan, Type=ClInclude]
│   └── targetver.h [realpath=targetver.h, UniqueIdentifier=nan, Type=ClInclude]
├── Resource Files [realpath=, UniqueIdentifier={67DA6AB6-F800-4c08-8B7A-83BB121AAD01}, Type=Filter]
└── ReadMe.txt [realpath=ReadMe.txt, UniqueIdentifier=nan, Type=None]

I will try to add the UniqueIdentifier to the non Filter types of the parent and add the realpath to the Filters

Thanks in advance and thanks for the library :)

Greets,
mr-nice